### PR TITLE
最近採用、いいねしたワード５件表示

### DIFF
--- a/app/assets/stylesheets/shared/side_bar.css
+++ b/app/assets/stylesheets/shared/side_bar.css
@@ -1,5 +1,5 @@
 .side-bar{
-  padding: 33px 15px 15px 0;
+  padding: 15px 15px 15px 0;
   width: 17%;
 }
 
@@ -15,10 +15,15 @@
 
 .list{
   text-align: center;
+  margin-bottom: 15px;
+}
+
+.good_adoption_words{
+  display: block;
 }
 
 .test{
-  padding: 10px;
+  padding: 0 10px 10px 10px;
 }
 
 .try-test{

--- a/app/controllers/adoptions_controller.rb
+++ b/app/controllers/adoptions_controller.rb
@@ -9,7 +9,7 @@ class AdoptionsController < ApplicationController
       meaning: @word.meaning, 
       genre_id: @word.genre_id, 
       text: @word.text, 
-      publish: @word.publish,
+      publish: false,
       user_id: current_user.id
       })
     @user = current_user

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,5 +3,7 @@ class UsersController < ApplicationController
     @user = User.find(params[:id])
     @word = Word.new
     @words = @user.words.order("created_at DESC")
+    @good_words = @user.good_words.order(created_at: :desc).limit(5)
+    @adoption_words = @user.adoption_words.order(created_at: :desc).limit(5)
   end
 end

--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -9,8 +9,9 @@ class Genre < ActiveHash::Base
     { id: 7, name: '歌手' },
     { id: 8, name: 'アニメ' },
     { id: 9, name: 'キャラ' },
-    { id: 10, name: 'カリキュラム' },
-    { id: 11, name: 'メモ' }
+    { id: 10, name: 'スポーツ' },
+    { id: 11, name: 'セクション' },
+    { id: 12, name: 'メモ' }
   ]
 
   include ActiveHash::Associations

--- a/app/models/word.rb
+++ b/app/models/word.rb
@@ -81,7 +81,7 @@ class Word < ApplicationRecord
     elsif condition == "5"
       Word.where(user_id: id).select('words.*', 'count(goods.id) AS goos').left_joins(:goods).group('words.id').order('goos desc')
     elsif condition == "6"
-      Word.where(user_id: id).order(name: :asc) #採用数順（保留）
+      Word.where(user_id: id).select('words.*', 'count(adoptions.id) AS ados').left_joins(:adoptions).group('words.id').order('ados desc')
     elsif condition == "7"
       Word.where(user_id: id).order(pos_id: :asc)
     elsif condition == "8"
@@ -99,7 +99,7 @@ class Word < ApplicationRecord
     elsif condition == "4"
       Word.select('words.*', 'count(goods.id) AS goos').left_joins(:goods).group('words.id').order('goos desc')
     elsif condition == "5"
-      Word.order(name: :asc) #採用数順（保留）
+      Word.select('words.*', 'count(adoptions.id) AS ados').left_joins(:adoptions).group('words.id').order('ados desc')
     elsif condition == "6"
       Word.order(pos_id: :asc)
     elsif condition == "7"

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -164,13 +164,29 @@
     <div class="side-bar-contents">
       <div class="publish-users">
         <div class="sub-title">
-          - ユーザー検索 -
+          - ワード検索 -
         </div>
         <div class="try-test">
-            <%= link_to "公開ワードを見に行く", root_path, class: "test-link"%>
+            <%= link_to "公開ワード検索", root_path, class: "test-link"%>
         </div>
-        <div class="list">過去にグーしたユーザー▼</div>
-        <div class="list">過去に採用したユーザー▼</div>
+        <div class="list">〜最近グーしたワード〜
+          <% if @good_words.present? %>
+            <% @good_words.each do |word| %>
+              <%= link_to word.name, user_path(word.user.id), class: "good_adoption_words"%>
+            <% end %>
+           <% else %>
+            <p>※グーワードはありません</p>
+          <% end %>
+        </div>
+        <div class="list">〜最近採用したワード〜
+          <% if @adoption_words.present? %>
+            <% @adoption_words.each do |word| %>
+              <%= link_to word.name, user_path(word.user.id), class: "good_adoption_words"%>
+            <% end %>
+          <% else %>
+            <p>※採用ワードはありません</p>
+          <% end %>
+        </div>
       </div>
       <div class="test">
         <div class="sub-title">


### PR DESCRIPTION
# What
- good_wordsモデルから５件、adoption_wordsモデルから５件ワードを取得する記述追加
- ビューの微調整
- ジャンル項目に「スポーツ」追加
- 採用数の並び替え機能の設定
- 採用時のワードは非公開デフォに変更

# Why
- ユーザが直近でいいね、採用をして興味を持ったワードがわかるようにし、またそのユーザページにすぐにアクセスできるようにするため
- 採用機能実装時に並び替えの設定をし忘れていたため
- 採用したワードを公開デフォにすると最初に投稿した人の採用数の伸び率に影響がありそうだったため